### PR TITLE
Mention .http syntax compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,5 +18,3 @@ jobs:
     permissions:
       contents: read
     uses: FollowTheProcess/ci/.github/workflows/Go.yml@v3
-    with:
-      linter: staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,170 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+    - golines
+
+  settings:
+    gofumpt:
+      extra-rules: true
+
+    golines:
+      max-len: 140
+
+linters:
+  default: all
+  disable:
+    - decorder # Don't care about this
+    - dupl # Basically every table driven test ever triggers this
+    - dupword # Messes with test cases more often than not
+    - err113 # Out of date
+    - exhaustruct # No
+    - forbidigo # Nothing to forbid
+    - funlen # Bad metric for complexity
+    - ginkgolinter # I don't use whatever this is
+    - gochecknoglobals # Globals are fine sometimes, use common sense
+    - gocyclo # cyclop does this instead
+    - godox # "todo" and "fixme" comments are allowed
+    - goheader # No need
+    - gosmopolitan # No need
+    - grouper # Imports take care of themselves, rest is common sense
+    - ireturn # This is just not necessary or practical in a real codebase
+    - lll # Auto formatters do this and what they can't do I don't care about
+    - maintidx # This is just the inverse of complexity... which is cyclop
+    - nestif # cyclop does this
+    - nlreturn # Similar to wsl, I think best left to judgement
+    - noinlineerr # Inline errors are fine
+    - nonamedreturns # Named returns are often helpful, it's naked returns that are the issue
+    - paralleltest # I've never had Go tests take longer than a few seconds, it's fine
+    - unparam # gopls is better and more subtle
+    - varnamelen # Lots of false positives of things that are fine
+    - wrapcheck # Not every error must be wrapped
+    - wsl # Very aggressive, some of this I like but tend to do anyway
+    - wsl_v5 # As above, just newer version
+
+  exclusions:
+    presets:
+      # See https://golangci-lint.run/usage/false-positives/#exclusion-presets
+      - comments # Revive in particular has lots of false positives
+      - std-error-handling
+      - common-false-positives
+    rules:
+      - path: _test\.go
+        linters:
+          - prealloc # These kinds of optimisations will make no difference to test code
+          - gosec # Tests don't need security stuff
+
+  settings:
+    cyclop:
+      max-complexity: 20
+
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: io/ioutil
+              desc: io/ioutil is deprecated, use io instead
+
+            - pkg: "math/rand$"
+              desc: use math/rand/v2 instead
+
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+
+    exhaustive:
+      check:
+        - switch
+        - map
+      default-signifies-exhaustive: true
+
+    staticcheck:
+      checks:
+        - all
+
+    gosec:
+      excludes:
+        - G104 # Errors not checked, handled by errcheck
+
+    govet:
+      enable-all: true
+
+    nakedret:
+      max-func-lines: 0 # Disallow any naked returns
+
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
+
+    usetesting:
+      context-background: true
+      context-todo: true
+      os-chdir: true
+      os-mkdir-temp: true
+      os-setenv: true
+      os-create-temp: true
+      os-temp-dir: true
+
+    revive:
+      max-open-files: 256
+      enable-all-rules: true
+      rules:
+        - name: add-constant
+          disabled: true # goconst does this
+
+        - name: argument-limit
+          arguments:
+            - 5
+
+        - name: cognitive-complexity
+          disabled: true # gocognit does this
+
+        - name: comment-spacings
+          arguments:
+            - "nolint:"
+
+        - name: cyclomatic
+          disabled: true # cyclop does this
+
+        - name: exported
+          arguments:
+            - checkPrivateReceivers
+            - checkPublicInterface
+
+        - name: function-length
+          disabled: true # Bad proxy for complexity
+
+        - name: function-result-limit
+          arguments:
+            - 3
+
+        - name: import-shadowing
+          disabled: true # predeclared does this
+
+        - name: line-length-limit
+          disabled: true # gofmt/golines handles this well enough
+
+        - name: max-public-structs
+          disabled: true # This is a dumb rule
+
+        - name: redefines-builtin-id
+          disabled: true # predeclared does this
+
+        - name: unhandled-error
+          arguments:
+            - fmt\.(Fp|P)rint(ln|f)?
+            - strings.Builder.Write(String|Byte)?
+            - bytes.Buffer.Write(String|Byte)?
+            - os.File.Close?
+
+        - name: flag-parameter
+          disabled: true # As far as I can work out this just doesn't like bools
+
+        - name: unused-parameter
+          disabled: true # The gopls unused analyzer covers this better
+
+        - name: unused-receiver
+          disabled: true # As above

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Execute `.http` files from the command line
 // Global variables (e.g. base url) can be defined with '@ident = <value>'
 @base = https://api.company.com
 
-// 3 '#' in a row mark a new HTTP request, with an optional name e.g. 'Delete employee 1'
-### [name]
+// 3 '#' in a row mark a new HTTP request, with an optional comment e.g. "Deletes employee 1"
+// This comment is effectively the description of the request
+### [comment]
 HTTP_METHOD <url>
 Header-Name: <header value>
 
@@ -40,22 +41,17 @@ HTTP_METHOD <url>
 
 // Global variables are interpolated like this
 ### Get employee 1
-GET {{base}}/employees/1
+GET {{ base }}/employees/1
 
 // Pass the body of requests like this
 ### Update employee 1 name
-PATCH {{base}}/employees/1
+PATCH {{ base }}/employees/1
 Content-Type: application/json
 
 {
   "name": "Namey McNamerson"
 }
 ```
-
-See the [Spec] and [Syntax Guide] for more info.
-
-> [!NOTE]
-> The custom javascript portions (e.g. the `{% ... %}` blocks) of the spec are **not** implemented as these are editor specific and require a javascript runtime.
 
 ## Installation
 
@@ -67,45 +63,98 @@ brew install --cask FollowTheProcess/tap/req
 
 ## Quickstart
 
-Given a `.http` file containing http requests like this:
+Given a `.http` file containing 1 or more http requests like this:
 
 ```plaintext
 // demo.http
 
-@base = https://localhost:5167
- 
-### Create a new item
-POST {{base}}/todoitems
-Content-Type: application/json
- 
-{
-  "id": "{{ $guid }}",
-  "name":"walk dog",
-  "isComplete":false
-}
- 
-### Get All items
-GET {{base}}/todoitems
- 
-### Update item
-PUT {{base}}/todoitems/1
-Content-Type: application/json
- 
-{
-  "id": 1,
-  "name":"walk dog",
-  "isComplete": true
-}
- 
-### Delete item
-DELETE {{base}}/todoitems/1
+@base = https://jsonplaceholder.typicode.com
+
+### Simple demo request
+# @name Demo
+GET {{ base }}/todos/1
+Accept: application/json
 ```
 
 You can invoke any one of them, like this...
 
 ```shell
-req do ./demo.http --request "Get All items"
+# req do [file] [request name]
+req do ./demo.http Demo
 ```
+
+### Compatibility
+
+While there is a strict specification for the format of pure HTTP requests ([RFC9110]). There is little/no formal specification for the evolution of the format used in this project, the
+closest things available are:
+
+- The [JetBrains HTTP Request in Editor Spec]
+- [JetBrains Syntax Guide]
+- The [VSCode REST Extension]
+
+And careful inspection of them reveals a number of discrepencies and inconsistencies between them. As a result, knowing which features/syntax to support for this project
+was... tricky. So this project is a best effort to support the syntax and features that I thought was most reasonable and achievable in a standalone command line tool
+not built into an IDE.
+
+Some of the more prominent differences are:
+
+#### Whitespace
+
+The [JetBrains HTTP Request in Editor Spec] specifies exact whitespace requirements between different sections e.g. a single `\n` character *must* follow a request line.
+
+See <https://github.com/JetBrains/http-request-in-editor-spec/blob/master/spec.md#23-whitespaces>
+
+This project makes no such requirement, whitespace is entirely ignored meaning the formatting of `.http` files is up to convention and/or automatic formatting tools
+
+#### Response Handlers
+
+The [JetBrains HTTP Request in Editor Spec] allows for custom JavaScript [Response Handlers](https://github.com/JetBrains/http-request-in-editor-spec/blob/master/spec.md#324-response-handler) (e.g. the `{% ... %}` blocks), that take the response and transform it in some way:
+
+```plaintext
+GET http://example.com/auth
+
+> {% client.global.set("auth", response.body.token);%}
+```
+
+This is not supported in `req` as it relies on editor-specific context and requires a JavaScript runtime.
+
+However, the version of this syntax where you dump the response body to a file *is* supported!
+
+```plaintext
+GET http://example.com/auth
+
+> ./response.json
+```
+
+#### Response Reference
+
+The [JetBrains HTTP Request in Editor Spec] allows for a [Response Reference](https://github.com/JetBrains/http-request-in-editor-spec/blob/master/spec.md#325-response-reference), but doesn't actually
+explain what that is or what should be done with it? So I've left it out for now 🤷🏻
+
+```plaintext
+GET http://example.com
+
+<> previous-response.200.json
+```
+
+> [!NOTE]
+> I can foresee a potential use for this syntax: Saving the first response to the filepath indicated and then the next time it runs, comparing the responses and generating a diff of the previous response vs the current one. This isn't
+> implemented yet but it's in the back of my mind for the future 👀
+
+#### Templating Syntax
+
+All the mentioned specs allow for some sort of templating inside the `.http` files e.g. declaring a base URL globally, then interpolating it in all request URLs
+
+The implementations designed to run in IDEs likely leverage the native templating capability of the host language (Kotlin in JetBrains' case and JavaScript for VSCode). This presents me an issue, as `req` is written in Go, the native
+templating syntax is a little different.
+
+Instead of `{{ base }}`, Go's templating requires a `.` for attribute access and templated variables to be exported so the direct equivalent would be `{{ .Base }}`. Likewise function calls like `{{ $random.uuid }}` would be something like `{{ .Random.UUID }}`
+
+I've chosen to use Go's native templating syntax *for now* to get this project off the ground and ensure it's got all the features I want it to have. However, swapping out the limited templating available to `.http` files to a custom
+implementation so that `req` may execute `.http` files compatible with both JetBrains IDEs and the VSCode REST Extension is *definitely* on my roadmap!
+
+> [!WARNING]
+> Until this is done, HTTP request files written for `req` will sadly not be compatible with other IDE based tools
 
 ### Credits
 
@@ -115,5 +164,7 @@ This package was created with [copier] and the [FollowTheProcess/go_copier] proj
 [FollowTheProcess/go_copier]: https://github.com/FollowTheProcess/go_copier
 [GitHub release]: https://github.com/FollowTheProcess/req/releases
 [homebrew]: https://brew.sh
-[Spec]: https://github.com/JetBrains/http-request-in-editor-spec
-[Syntax Guide]: https://www.jetbrains.com/help/idea/exploring-http-syntax.html
+[JetBrains Syntax Guide]: https://www.jetbrains.com/help/idea/exploring-http-syntax.html
+[RFC9110]: https://www.rfc-editor.org/rfc/rfc9110.html
+[JetBrains HTTP Request in Editor Spec]: https://github.com/JetBrains/http-request-in-editor-spec
+[VSCode REST Extension]: https://github.com/Huachao/vscode-restclient

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ closest things available are:
 - [JetBrains Syntax Guide]
 - The [VSCode REST Extension]
 
-And careful inspection of them reveals a number of discrepencies and inconsistencies between them. As a result, knowing which features/syntax to support for this project
+And careful inspection of them reveals a number of discrepancies and inconsistencies between them. As a result, knowing which features/syntax to support for this project
 was... tricky. So this project is a best effort to support the syntax and features that I thought was most reasonable and achievable in a standalone command line tool
 not built into an IDE.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -72,8 +72,8 @@ tasks:
     sources:
       - "**/*.go"
     preconditions:
-      - sh: command -v staticcheck
-        msg: staticcheck not installed, see https://staticcheck.dev/docs/getting-started/
+      - sh: command -v golangci-lint
+        msg: golangci-lint not installed, run `brew install golangci-lint`
 
       - sh: command -v typos
         msg: requires typos-cli, run `brew install typos-cli`
@@ -81,7 +81,7 @@ tasks:
       - sh: command -v nilaway
         msg: requires nilaway, see https://github.com/uber-go/nilaway
     cmds:
-      - staticcheck -checks all ./...
+      - golangci-lint run
       - typos
       - nilaway ./...
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -265,6 +265,7 @@ func ResolveFile(in syntax.File) (File, error) {
 		Timeout:           in.Timeout,
 		ConnectionTimeout: in.ConnectionTimeout,
 		NoRedirect:        in.NoRedirect,
+		Prompts:           resolvePrompts(in.Prompts),
 	}
 
 	// Note: We could use something like text/template but I wanted to try and be compatible with
@@ -318,6 +319,16 @@ func ResolveFile(in syntax.File) (File, error) {
 	return resolved, nil
 }
 
+// resolvePrompts converts a []syntax.Prompt to a []Prompt.
+func resolvePrompts(in []syntax.Prompt) []Prompt {
+	resolved := make([]Prompt, 0, len(in))
+	for _, prompt := range in {
+		resolved = append(resolved, Prompt{Name: prompt.Name, Description: prompt.Description})
+	}
+
+	return resolved
+}
+
 // resolveRequest converts a [syntax.Request] to a [Request], performing variable
 // resolution and other validation.
 func resolveRequest(in syntax.Request, globals map[string]string) (Request, error) {
@@ -325,6 +336,7 @@ func resolveRequest(in syntax.Request, globals map[string]string) (Request, erro
 	resolved := Request{
 		Name:              in.Name,
 		Comment:           in.Comment,
+		Prompts:           resolvePrompts(in.Prompts),
 		Method:            in.Method,
 		BodyFile:          in.BodyFile,
 		ResponseFile:      in.ResponseFile,
@@ -363,13 +375,6 @@ func resolveRequest(in syntax.Request, globals map[string]string) (Request, erro
 	}
 
 	resolved.Vars = vars
-
-	prompts := make([]Prompt, 0, len(in.Prompts))
-	for _, prompt := range in.Prompts {
-		prompts = append(prompts, Prompt{Name: prompt.Name, Description: prompt.Description})
-	}
-
-	resolved.Prompts = prompts
 
 	headers := make(map[string]string, len(in.Headers))
 	for key, value := range in.Headers {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -58,6 +58,25 @@ func TestResolve(t *testing.T) {
 			errMsg:  "",
 		},
 		{
+			name: "global prompts",
+			in: syntax.File{
+				Name: "globals",
+				Prompts: []syntax.Prompt{
+					{Name: "value", Description: "Give me a value"},
+				},
+			},
+			want: spec.File{
+				Name: "globals",
+				Prompts: []spec.Prompt{
+					{Name: "value", Description: "Give me a value"},
+				},
+				Timeout:           spec.DefaultTimeout,
+				ConnectionTimeout: spec.DefaultConnectionTimeout,
+			},
+			wantErr: false,
+			errMsg:  "",
+		},
+		{
 			name: "globals with interpolation",
 			in: syntax.File{
 				Name: "globals",
@@ -180,6 +199,65 @@ func TestResolve(t *testing.T) {
 						},
 						Vars: map[string]string{
 							"something": "123",
+						},
+						Name:              "#1",
+						Method:            "POST",
+						URL:               "https://api.com/items/1",
+						Body:              []byte(`{"message": "here", "user": "123"}`),
+						Timeout:           spec.DefaultTimeout,
+						ConnectionTimeout: spec.DefaultConnectionTimeout,
+					},
+				},
+				Timeout:           spec.DefaultTimeout,
+				ConnectionTimeout: spec.DefaultConnectionTimeout,
+			},
+			wantErr: false,
+			errMsg:  "",
+		},
+		{
+			name: "single request with prompt",
+			in: syntax.File{
+				Name: "test.http",
+				Vars: map[string]string{
+					"base":    "https://api.com",
+					"user_id": "123",
+				},
+				Requests: []syntax.Request{
+					{
+						Headers: map[string]string{
+							"Content-Type": "application/json",
+							"X-User-ID":    "{{user_id}}",
+						},
+						Vars: map[string]string{
+							"something": "{{user_id}}",
+						},
+						Prompts: []syntax.Prompt{
+							{Name: "value", Description: "Give me a value"},
+						},
+						Name:   "#1",
+						Method: "POST",
+						URL:    "{{base}}/items/1",
+						Body:   []byte(`{"message": "here", "user": "{{user_id}}"}`),
+					},
+				},
+			},
+			want: spec.File{
+				Name: "test.http",
+				Vars: map[string]string{
+					"base":    "https://api.com",
+					"user_id": "123",
+				},
+				Requests: []spec.Request{
+					{
+						Headers: map[string]string{
+							"Content-Type": "application/json",
+							"X-User-ID":    "123",
+						},
+						Vars: map[string]string{
+							"something": "123",
+						},
+						Prompts: []spec.Prompt{
+							{Name: "value", Description: "Give me a value"},
 						},
 						Name:              "#1",
 						Method:            "POST",

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,3 +1,0 @@
-# https://staticcheck.dev/docs/configuration/options/
-checks = ["all"]
-http_status_code_whitelist = []


### PR DESCRIPTION
- **Document Go template syntax incompatibilities**
- **Get golangci-lint working as an LSP in Zed**
- **Add resolve tests for prompts**

# Summary
<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
